### PR TITLE
Add Tally intergration

### DIFF
--- a/frontend/state/eth.ts
+++ b/frontend/state/eth.ts
@@ -28,6 +28,7 @@ const wallets: (WalletModule | WalletInitOptions)[] = [
       [networkId]: process.env.NEXT_PUBLIC_RPC_URL ?? "",
     },
   },
+  { walletName: "tally" },
 ];
 
 // Token name


### PR DESCRIPTION
Add support for [Tally](https://tally.cash/) wallet. Tally is an open-source browser extension similar to Metamask.